### PR TITLE
Profile stale, getProfile race condition and bug fixes.

### DIFF
--- a/src/hooks/useFollowing.ts
+++ b/src/hooks/useFollowing.ts
@@ -1,6 +1,6 @@
-import { useMemo } from "react";
 import { debug } from "@bsky/shared";
 import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
 import { useAuth } from "../contexts/AuthContext";
 
 export function useFollowing() {
@@ -51,7 +51,7 @@ export function useFollowing() {
   // Create a stable reference for the Set to prevent unnecessary re-renders
   const stableFollowingSet = useMemo(() => {
     if (!query.data) return undefined;
-    
+
     // Convert Set to array, sort it for consistent ordering, then back to Set
     // This ensures the same content always produces the same reference
     const sortedDids = Array.from(query.data).sort();

--- a/src/services/follower-cache-db.ts
+++ b/src/services/follower-cache-db.ts
@@ -139,8 +139,12 @@ export class FollowerCacheDB {
     }
     const tx = this.db.transaction(["profiles"], "readonly");
     const request = tx.objectStore("profiles").get(did);
-    const result = await request;
-    return result as unknown as CachedProfile | undefined;
+    return new Promise<CachedProfile | undefined>((resolve, reject) => {
+      request.onsuccess = () => {
+        resolve(request.result as CachedProfile | undefined);
+      };
+      request.onerror = () => reject(request.error);
+    });
   }
 
   async getProfileByHandle(handle: string): Promise<CachedProfile | undefined> {

--- a/src/services/profile-cache-service.ts
+++ b/src/services/profile-cache-service.ts
@@ -70,7 +70,7 @@ export class ProfileCacheService {
                 ...cachedProfile,
                 fromCache: false,
               });
-              
+
               // Save to cache immediately to prevent race conditions
               await db.saveProfile(cachedProfile);
             }
@@ -136,7 +136,7 @@ export class ProfileCacheService {
             if (response.data) {
               const cachedProfile = profileToCached(response.data);
               profileMap.set(did, { ...cachedProfile, fromCache: false });
-              
+
               // Save to cache immediately to prevent race conditions
               await db.saveProfile(cachedProfile);
             }
@@ -144,7 +144,6 @@ export class ProfileCacheService {
             debug.error(`Error fetching profile for ${did}:`, error);
           }
         }
-
       } catch (error) {
         debug.error("Error fetching profiles by DID:", error);
         // Fall back to stale cache


### PR DESCRIPTION
### Problem 1:
`FollowerCacheDB.isProfileStale` always return falsy (actually undefined). Causing profiles to always be stale.

Root cause: `getProfile` was returning the `IDBRequest` itself. In JS, await on a non-Promise returns the value unchanged, so await request gave the request object. `profile.lastFetched` comes out undefined because we’re accessing a property on the request object, not the record.

Fix applied: `getProfile` now resolves the request’s result via onsuccess and returns the actual `CachedProfile`.

### Problem 2:
Race condition while fetching getProfile from Bluesky API.

Root cause: `ProfileCacheService.getProfilesWithCache` and `ProfileCacheService.getProfilesByDidsWithCache`, uses `db.saveProfiles(profilesToCache)` _**after**_ fetching _**all**_ the records.

For my test account, I was following around 400 people, and while testing `getProfile` on average took 300ms, = total 2mins.
If react initiates any refresh (say, due to `useEffect` refresh somewhere), we'll have to refetch from start (multiple concurrent requests). This will keep on happening till all profiles are fetched and saved, and for larger following this will take a while, hence the race condition.

Fix applied: Save on the go, without waiting for all requests to complete. This should also help reduce load on Bluesky APIs caused due to this race condition. 

### Problem 3
`useFollowing` may cause unnecessary refreshes to which ever useEffect uses it. 
Root cause: Not memoised.
Fix applied: Create a stable reference for the Set to prevent unnecessary re-renders