### PR TITLE
Trim the @ from the start of the handle

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -188,8 +188,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
           atProtoClient.updateService(pdsUrl);
         }
 
+        const trimAt = (s: string) => s.length > 0 && s[0] === "@" ? s.slice(1) : s;
+
         const newSession = await atProtoClient.login(
-          identifier,
+          trimAt(identifier),
           password,
           authFactorToken,
         );


### PR DESCRIPTION
Currently this blocks login if someone takes the placeholder @handle.bsky.social literally, which did actually prevent me from using shadowsky previously. I pulled code because I assumed it was sanitation on my generated password but it turns out it was just the @ at the beginning.

I am aware the repo is not officially maintained/etc but the change is pretty trivial and is likely to net more use.