### PR TITLE
make it possible to have full width columns like on the real bsky app, a

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bsky-notifications-app",
-  "version": "0.7.4",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bsky-notifications-app",
-      "version": "0.7.4",
+      "version": "0.8.0",
       "workspaces": [
         "packages/*"
       ],

--- a/src/components/SkyDeck.tsx
+++ b/src/components/SkyDeck.tsx
@@ -172,7 +172,7 @@ export default function SkyDeck() {
   const [mobileColumnIndex, setMobileColumnIndex] = useState(0);
   const [customFeedUri, setCustomFeedUri] = useState("");
   const [isLoadingCustomFeed, setIsLoadingCustomFeed] = useState(false);
-  const [columnWidth, setColumnWidth] = useState(320); // Default width
+  const [columnWidth, setColumnWidth] = useState(0); // Default: full width (0 = full)
   const columnsContainerRef = useRef<HTMLDivElement>(null);
   const columnSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const columnsLoadedRef = useRef(false);
@@ -366,8 +366,8 @@ export default function SkyDeck() {
       const storageType = appPreferences?.columnStorageType || "local";
       await columnService.initialize(agent, storageType);
 
-      // Set column width from preferences
-      if (appPreferences?.columnWidth) {
+      // Set column width from preferences (0 = full width)
+      if (appPreferences && appPreferences.columnWidth != null) {
         setColumnWidth(appPreferences.columnWidth);
       }
 
@@ -545,6 +545,14 @@ export default function SkyDeck() {
     containerRef: mobileContainerRef,
   });
 
+  const isFullWidth = columnWidth === 0;
+
+  // Helper to get icon for a column type
+  const getColumnIcon = (type: ColumnType) => {
+    const option = columnOptions.find((opt) => opt.type === type);
+    return option?.icon || Hash;
+  };
+
   // In narrow view, show columns with swipe navigation
   if (isNarrowView && columns.length > 0) {
     const currentColumn = columns[mobileColumnIndex] || columns[0];
@@ -598,7 +606,120 @@ export default function SkyDeck() {
     );
   }
 
-  // Full multi-column view for wider screens
+  // Full-width single-column view (like the real Bluesky app)
+  if (isFullWidth && columns.length > 0) {
+    const currentColumn = columns[focusedColumnIndex] || columns[0];
+
+    return (
+      <div className="flex h-full flex-col overflow-hidden bg-asph-bg-primary">
+        {/* Column tab bar */}
+        {columns.length > 1 && (
+          <div className="flex items-center gap-1 border-b border-asph-border-primary bg-asph-bg-secondary px-2">
+            <div className="asph-scrollbar flex flex-1 items-center gap-1 overflow-x-auto py-1">
+              {columns.map((col, index) => {
+                const Icon = getColumnIcon(col.type);
+                return (
+                  <button
+                    key={`tab-${col.id}`}
+                    onClick={() => setFocusedColumnIndex(index)}
+                    className={`flex shrink-0 items-center gap-1.5 rounded-md px-3 py-1.5 text-sm transition-colors ${
+                      focusedColumnIndex === index
+                        ? "bg-asph-bg-active font-medium text-asph-text-primary"
+                        : "text-asph-text-secondary hover:bg-asph-bg-hover hover:text-asph-text-primary"
+                    }`}
+                    aria-current={
+                      focusedColumnIndex === index ? "true" : undefined
+                    }
+                  >
+                    <Icon className="h-4 w-4" />
+                    <span className="max-w-[120px] truncate">
+                      {col.title || col.type}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+            <button
+              onClick={() => setIsAddingColumn(true)}
+              className="shrink-0 rounded-md p-1.5 text-asph-text-tertiary transition-colors hover:bg-asph-bg-hover hover:text-asph-text-primary"
+              aria-label="Add column"
+            >
+              <Plus className="h-4 w-4" />
+            </button>
+          </div>
+        )}
+
+        {/* Full-width column content */}
+        <div className="relative flex-1 overflow-hidden">
+          <div className="mx-auto h-full w-full max-w-2xl">
+            <SkyColumn
+              key={currentColumn.id}
+              column={currentColumn}
+              onClose={() => handleRemoveColumn(currentColumn.id)}
+              onMoveLeft={
+                focusedColumnIndex > 0
+                  ? () => {
+                      handleMoveLeft(currentColumn.id);
+                      setFocusedColumnIndex(focusedColumnIndex - 1);
+                    }
+                  : undefined
+              }
+              onMoveRight={
+                focusedColumnIndex < columns.length - 1
+                  ? () => {
+                      handleMoveRight(currentColumn.id);
+                      setFocusedColumnIndex(focusedColumnIndex + 1);
+                    }
+                  : undefined
+              }
+              isFocused={true}
+            />
+          </div>
+        </div>
+
+        {/* Add column panel (full-width mode) */}
+        {isAddingColumn && (
+          <div className="absolute inset-0 z-50 flex items-start justify-center bg-black/50 pt-16">
+            <div className="mx-4 w-full max-w-md animate-fade-in rounded-lg border border-asph-border-primary bg-asph-bg-secondary p-4 shadow-xl">
+              <h3 className="mb-3 text-sm font-medium text-asph-text-primary">
+                Add Column
+              </h3>
+              <div className="grid gap-2">
+                {columnOptions.map((option) => {
+                  const Icon = option.icon;
+                  return (
+                    <button
+                      key={option.type}
+                      onClick={() => handleAddColumn(option.type)}
+                      className="touch-target flex items-center gap-3 rounded-md border border-asph-border-primary p-3 text-left transition-colors hover:bg-asph-bg-hover"
+                    >
+                      <Icon className="h-5 w-5 text-blue-500" />
+                      <div>
+                        <div className="font-medium text-asph-text-primary">
+                          {option.label}
+                        </div>
+                        <div className="text-sm text-asph-text-tertiary">
+                          {option.description}
+                        </div>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+              <button
+                onClick={() => setIsAddingColumn(false)}
+                className="mt-3 w-full rounded-md bg-asph-bg-tertiary px-4 py-2 text-asph-text-secondary transition-colors hover:bg-asph-bg-active"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // Multi-column deck view for wider screens
   return (
     <div className="flex h-full flex-col overflow-hidden bg-asph-bg-primary">
       <div className="skydeck-columns-scrollbar flex-1 overflow-x-auto overflow-y-hidden p-3">

--- a/src/components/settings/AppearanceSettings.tsx
+++ b/src/components/settings/AppearanceSettings.tsx
@@ -5,11 +5,19 @@ import { useAuth } from "../../contexts/AuthContext";
 import { useTheme } from "../../contexts/ThemeContext";
 import { appPreferencesService } from "../../services/app-preferences-service";
 
+const WIDTH_OPTIONS = [
+  { value: 0, label: "Full Width" },
+  { value: 280, label: "Compact" },
+  { value: 320, label: "Medium" },
+  { value: 360, label: "Comfortable" },
+  { value: 400, label: "Spacious" },
+];
+
 export const AppearanceSettings: React.FC = () => {
   const { theme, setTheme } = useTheme();
   const { agent } = useAuth();
   const queryClient = useQueryClient();
-  const [selectedWidth, setSelectedWidth] = useState(320);
+  const [selectedWidth, setSelectedWidth] = useState(0);
 
   // Get current preferences
   const { data: appPreferences } = useQuery({
@@ -24,7 +32,7 @@ export const AppearanceSettings: React.FC = () => {
 
   // Load column width from preferences
   useEffect(() => {
-    if (appPreferences?.columnWidth) {
+    if (appPreferences && appPreferences.columnWidth != null) {
       setSelectedWidth(appPreferences.columnWidth);
     }
   }, [appPreferences]);
@@ -194,69 +202,64 @@ export const AppearanceSettings: React.FC = () => {
             className="mb-4 text-sm"
             style={{ color: "var(--asph-text-secondary)" }}
           >
-            Adjust the width of columns in your home feed. Smaller widths allow
-            more columns to fit on screen.
+            Choose how columns are displayed. Full width shows one column at a
+            time like the standard Bluesky app. Fixed widths show multiple
+            columns side by side.
           </p>
           <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <label
-                className="text-sm font-medium"
-                style={{ color: "var(--asph-text-primary)" }}
-              >
-                Width: {selectedWidth}px
-              </label>
-              <span
-                className="text-xs"
-                style={{ color: "var(--asph-text-secondary)" }}
-              >
-                {selectedWidth === 280 && "Compact"}
-                {selectedWidth === 320 && "Default"}
-                {selectedWidth === 360 && "Comfortable"}
-                {selectedWidth === 400 && "Spacious"}
-              </span>
-            </div>
-            <input
-              type="range"
-              min="280"
-              max="400"
-              step="40"
-              value={selectedWidth}
-              onChange={(e) => setSelectedWidth(Number(e.target.value))}
-              className="h-2 w-full cursor-pointer appearance-none rounded-lg"
-              style={{
-                background: `linear-gradient(to right, var(--asph-primary) 0%, var(--asph-primary) ${((selectedWidth - 280) / 120) * 100}%, var(--asph-bg-tertiary) ${((selectedWidth - 280) / 120) * 100}%, var(--asph-bg-tertiary) 100%)`,
-              }}
-            />
-            <div
-              className="flex justify-between text-xs"
-              style={{ color: "var(--asph-text-secondary)" }}
-            >
-              <span>280px</span>
-              <span>320px</span>
-              <span>360px</span>
-              <span>400px</span>
+            <div className="grid gap-2">
+              {WIDTH_OPTIONS.map((option) => (
+                <button
+                  key={option.value}
+                  onClick={() => setSelectedWidth(option.value)}
+                  className={`touch-target flex items-center justify-between rounded-lg border-2 px-4 py-3 text-left transition-all ${
+                    selectedWidth === option.value
+                      ? "border-blue-500"
+                      : "border-transparent hover:border-asph-border-secondary"
+                  }`}
+                  style={{
+                    backgroundColor:
+                      selectedWidth === option.value
+                        ? "var(--asph-bg-tertiary)"
+                        : "var(--asph-bg-primary)",
+                  }}
+                >
+                  <span
+                    className="text-sm font-medium"
+                    style={{ color: "var(--asph-text-primary)" }}
+                  >
+                    {option.label}
+                  </span>
+                  <span
+                    className="text-xs"
+                    style={{ color: "var(--asph-text-tertiary)" }}
+                  >
+                    {option.value === 0 ? "Single column" : `${option.value}px`}
+                  </span>
+                </button>
+              ))}
             </div>
             <button
               onClick={() => updateColumnWidth.mutate(selectedWidth)}
               disabled={
                 updateColumnWidth.isPending ||
-                selectedWidth === appPreferences?.columnWidth
+                selectedWidth === (appPreferences?.columnWidth ?? 0)
               }
               className="touch-target-sm mt-3 rounded px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50"
               style={{
                 backgroundColor:
                   updateColumnWidth.isPending ||
-                  selectedWidth === appPreferences?.columnWidth
+                  selectedWidth === (appPreferences?.columnWidth ?? 0)
                     ? "var(--asph-bg-tertiary)"
                     : "var(--asph-primary)",
                 color:
                   updateColumnWidth.isPending ||
-                  selectedWidth === appPreferences?.columnWidth
+                  selectedWidth === (appPreferences?.columnWidth ?? 0)
                     ? "var(--asph-text-secondary)"
                     : "white",
               }}
             >
-              {updateColumnWidth.isPending ? "Applying..." : "Apply Width"}
+              {updateColumnWidth.isPending ? "Applying..." : "Apply Layout"}
             </button>
           </div>
         </div>

--- a/src/hooks/useSidebarManagement.ts
+++ b/src/hooks/useSidebarManagement.ts
@@ -11,6 +11,7 @@ const DEFAULT_COLUMN_WIDTH = 320;
  * Sidebar: 256px, 3 columns: 3*columnWidth + 2*12px gap + 24px padding
  */
 function collapseThreshold(columnWidth: number): number {
+  if (columnWidth === 0) return 0; // Full-width: never auto-collapse
   return 256 + 3 * columnWidth + 2 * 12 + 24;
 }
 
@@ -39,7 +40,9 @@ export function useSidebarManagement(isAuthenticated: boolean) {
 
     void appPreferencesService.getPreferences().then((prefs) => {
       if (cancelled) return; // Stale async result — discard
-      setColumnWidth(prefs?.columnWidth || DEFAULT_COLUMN_WIDTH);
+      setColumnWidth(
+        prefs?.columnWidth != null ? prefs.columnWidth : DEFAULT_COLUMN_WIDTH,
+      );
     });
 
     return () => {


### PR DESCRIPTION
## Summary
Added a full-width single-column layout mode to SkyDeck that mimics the real Bluesky app experience. When in full-width mode (`columnWidth=0`, now the default), one column is shown at a time filling the content area (centered with `max-w-2xl`), with a tab bar at the top for switching between columns. This replaces the previous default of 320px-wide side-by-side columns. The multi-column deck view is still available via Settings > Appearance > Column Width where users can choose Fixed widths (280/320/360/400px). Fixed several places where `columnWidth=0` was incorrectly treated as falsy (skipped by truthy checks in SkyDeck, AppearanceSettings, and useSidebarManagement).

**Asana Task:** 1215602649874540
**Agent:** frontend-specialist

_Auto-generated by task executor. Auto-merge enabled._