### PR TITLE
Show the skysight.live feeds as official picks on the discover tab and i

### DIFF
--- a/src/components/discover/DiscoverFeeds.tsx
+++ b/src/components/discover/DiscoverFeeds.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check, Hash, Plus, Search, Users } from "lucide-react";
+import { Check, Hash, Plus, Search, Sparkles, Users } from "lucide-react";
 import React, { useContext, useState } from "react";
+import { CURATED_FEED_URIS } from "../../config/curated-feeds";
 import { AuthContext } from "../../contexts/AuthContext";
 import { proxifyBskyImage } from "../../utils/image-proxy";
 
@@ -23,14 +24,14 @@ interface FeedGenerator {
   };
 }
 
+type FeedSubTab = "picks" | "suggested" | "popular";
+
 export const DiscoverFeeds: React.FC = () => {
   const authContext = useContext(AuthContext);
   const agent = authContext?.agent ?? null;
   const queryClient = useQueryClient();
   const [searchQuery, setSearchQuery] = useState("");
-  const [activeSubTab, setActiveSubTab] = useState<"suggested" | "popular">(
-    "suggested",
-  );
+  const [activeSubTab, setActiveSubTab] = useState<FeedSubTab>("picks");
 
   const { data: userPrefs } = useQuery({
     queryKey: ["userPreferences"],
@@ -46,7 +47,12 @@ export const DiscoverFeeds: React.FC = () => {
     queryFn: async () => {
       if (!agent) throw new Error("Not authenticated");
 
-      if (activeSubTab === "suggested") {
+      if (activeSubTab === "picks") {
+        const response = await agent.app.bsky.feed.getFeedGenerators({
+          feeds: CURATED_FEED_URIS,
+        });
+        return response.data.feeds;
+      } else if (activeSubTab === "suggested") {
         const response = await agent.app.bsky.feed.getSuggestedFeeds({
           limit: 50,
         });
@@ -138,38 +144,42 @@ export const DiscoverFeeds: React.FC = () => {
       </div>
 
       <div className="flex gap-2">
-        <button
-          onClick={() => setActiveSubTab("suggested")}
-          className="touch-target rounded-full px-4 py-1.5 text-sm font-medium transition-colors"
-          style={{
-            backgroundColor:
-              activeSubTab === "suggested"
-                ? "var(--asph-primary)"
-                : "var(--asph-bg-secondary)",
-            color:
-              activeSubTab === "suggested"
-                ? "white"
-                : "var(--asph-text-secondary)",
-          }}
-        >
-          Suggested
-        </button>
-        <button
-          onClick={() => setActiveSubTab("popular")}
-          className="touch-target rounded-full px-4 py-1.5 text-sm font-medium transition-colors"
-          style={{
-            backgroundColor:
-              activeSubTab === "popular"
-                ? "var(--asph-primary)"
-                : "var(--asph-bg-secondary)",
-            color:
-              activeSubTab === "popular"
-                ? "white"
-                : "var(--asph-text-secondary)",
-          }}
-        >
-          Popular
-        </button>
+        {(
+          [
+            {
+              key: "picks" as FeedSubTab,
+              label: "Our Picks",
+              icon: Sparkles as React.ElementType | undefined,
+            },
+            {
+              key: "suggested" as FeedSubTab,
+              label: "Suggested",
+              icon: undefined as React.ElementType | undefined,
+            },
+            {
+              key: "popular" as FeedSubTab,
+              label: "Popular",
+              icon: undefined as React.ElementType | undefined,
+            },
+          ] as const
+        ).map(({ key, label, icon: TabIcon }) => (
+          <button
+            key={key}
+            onClick={() => setActiveSubTab(key)}
+            className="touch-target flex items-center gap-1.5 rounded-full px-4 py-1.5 text-sm font-medium transition-colors"
+            style={{
+              backgroundColor:
+                activeSubTab === key
+                  ? "var(--asph-primary)"
+                  : "var(--asph-bg-secondary)",
+              color:
+                activeSubTab === key ? "white" : "var(--asph-text-secondary)",
+            }}
+          >
+            {TabIcon && <TabIcon size={14} />}
+            {label}
+          </button>
+        ))}
       </div>
 
       {isLoading ? (

--- a/src/components/search/SearchTabFeeds.tsx
+++ b/src/components/search/SearchTabFeeds.tsx
@@ -3,6 +3,7 @@ import { debug } from "@bsky/shared";
 import { useQuery } from "@tanstack/react-query";
 import { ExternalLink, List } from "lucide-react";
 import React from "react";
+import { CURATED_FEED_URIS } from "../../config/curated-feeds";
 import { proxifyBskyImage } from "../../utils/image-proxy";
 import { LoadingState } from "../ui/LoadingState";
 
@@ -25,18 +26,23 @@ export const SearchTabFeeds: React.FC<SearchTabFeedsProps> = React.memo(
         if (!activeSearchQuery.trim()) return null;
 
         try {
-          // Get popular feeds and user's feeds
-          const [popularResponse, suggestedResponse] = await Promise.all([
-            agent!.app.bsky.unspecced.getPopularFeedGenerators({
-              limit: 50,
-            }),
-            agent!.app.bsky.feed.getSuggestedFeeds({
-              limit: 50,
-            }),
-          ]);
+          // Get popular feeds, suggested feeds, and curated picks
+          const [popularResponse, suggestedResponse, curatedResponse] =
+            await Promise.all([
+              agent!.app.bsky.unspecced.getPopularFeedGenerators({
+                limit: 50,
+              }),
+              agent!.app.bsky.feed.getSuggestedFeeds({
+                limit: 50,
+              }),
+              agent!.app.bsky.feed.getFeedGenerators({
+                feeds: CURATED_FEED_URIS,
+              }),
+            ]);
 
           // Combine and deduplicate feeds
           const allFeeds = [
+            ...curatedResponse.data.feeds,
             ...popularResponse.data.feeds,
             ...suggestedResponse.data.feeds,
           ];

--- a/src/config/curated-feeds.ts
+++ b/src/config/curated-feeds.ts
@@ -1,0 +1,108 @@
+export const SKYSIGHT_DID = "did:plc:mp33qrwuvsxucbzoh7kykslu";
+
+export interface CuratedFeed {
+  uri: string;
+  category: "popular" | "topic" | "cross-platform";
+}
+
+export const CURATED_FEEDS: CuratedFeed[] = [
+  // Popular / general
+  {
+    uri: `at://${SKYSIGHT_DID}/app.bsky.feed.generator/popular`,
+    category: "popular",
+  },
+  {
+    uri: `at://${SKYSIGHT_DID}/app.bsky.feed.generator/joy`,
+    category: "popular",
+  },
+  {
+    uri: `at://${SKYSIGHT_DID}/app.bsky.feed.generator/pan-curated`,
+    category: "popular",
+  },
+
+  // Topic feeds
+  {
+    uri: `at://${SKYSIGHT_DID}/app.bsky.feed.generator/ai-agents`,
+    category: "topic",
+  },
+  {
+    uri: `at://${SKYSIGHT_DID}/app.bsky.feed.generator/ai-practitioner`,
+    category: "topic",
+  },
+  {
+    uri: `at://${SKYSIGHT_DID}/app.bsky.feed.generator/science`,
+    category: "topic",
+  },
+  {
+    uri: `at://${SKYSIGHT_DID}/app.bsky.feed.generator/smart-policy`,
+    category: "topic",
+  },
+  {
+    uri: `at://${SKYSIGHT_DID}/app.bsky.feed.generator/policy-insiders`,
+    category: "topic",
+  },
+  {
+    uri: `at://${SKYSIGHT_DID}/app.bsky.feed.generator/economics`,
+    category: "topic",
+  },
+  {
+    uri: `at://${SKYSIGHT_DID}/app.bsky.feed.generator/pure-finance`,
+    category: "topic",
+  },
+  {
+    uri: `at://${SKYSIGHT_DID}/app.bsky.feed.generator/finance-discussion`,
+    category: "topic",
+  },
+  {
+    uri: `at://${SKYSIGHT_DID}/app.bsky.feed.generator/climate-tech`,
+    category: "topic",
+  },
+  {
+    uri: `at://${SKYSIGHT_DID}/app.bsky.feed.generator/global-health`,
+    category: "topic",
+  },
+  {
+    uri: `at://${SKYSIGHT_DID}/app.bsky.feed.generator/effective-altruism`,
+    category: "topic",
+  },
+  {
+    uri: `at://${SKYSIGHT_DID}/app.bsky.feed.generator/girlies`,
+    category: "topic",
+  },
+  {
+    uri: `at://${SKYSIGHT_DID}/app.bsky.feed.generator/maga-troll-detector`,
+    category: "topic",
+  },
+  {
+    uri: `at://${SKYSIGHT_DID}/app.bsky.feed.generator/after-dark`,
+    category: "topic",
+  },
+
+  // Cross-platform feeds
+  {
+    uri: `at://${SKYSIGHT_DID}/app.bsky.feed.generator/cross-platform`,
+    category: "cross-platform",
+  },
+  {
+    uri: `at://${SKYSIGHT_DID}/app.bsky.feed.generator/arxiv-discussed`,
+    category: "cross-platform",
+  },
+  {
+    uri: `at://${SKYSIGHT_DID}/app.bsky.feed.generator/reddit-discussed`,
+    category: "cross-platform",
+  },
+  {
+    uri: `at://${SKYSIGHT_DID}/app.bsky.feed.generator/youtube-discussed`,
+    category: "cross-platform",
+  },
+  {
+    uri: `at://${SKYSIGHT_DID}/app.bsky.feed.generator/twitter-discussed`,
+    category: "cross-platform",
+  },
+  {
+    uri: `at://${SKYSIGHT_DID}/app.bsky.feed.generator/tiktok-discussed`,
+    category: "cross-platform",
+  },
+];
+
+export const CURATED_FEED_URIS = CURATED_FEEDS.map((f) => f.uri);


### PR DESCRIPTION
## Summary
Added all 23 skysight.live feed generators as curated "Official Picks" in the Discover tab and merged them into the feed search pool. The skysight.live account (`did:plc:mp33qrwuvsxucbzoh7kykslu`) hosts feeds covering AI, policy, finance, science, cross-platform discussions, and more — all served from `did:web:feed.shadowsky.io` (our own infra). The Discover Feeds tab now defaults to "Our Picks" (with a sparkle icon) which fetches the curated feeds via `getFeedGenerators`. The search tab now includes curated feeds alongside popular/suggested feeds, so they surface when users search by name, description, or creator handle.

**Asana Task:** 1217168091121004
**Agent:** frontend-specialist

_Auto-generated by task executor. Auto-merge enabled._