### PR TITLE
[BSKY] Global test setup stubs localStorage with no-op vi.fn()s — storag

### DIFF
--- a/src/services/network-weather.test.ts
+++ b/src/services/network-weather.test.ts
@@ -46,28 +46,7 @@ async function load() {
   return await import("./network-weather");
 }
 
-// The global test setup (src/tests/setup.ts) replaces localStorage with bare
-// vi.fn() stubs that never store anything, so snapshot round-trips can't be
-// observed through it. These tests need real read-back behaviour.
-function installMemoryStorage() {
-  const store = new Map<string, string>();
-  Object.defineProperty(globalThis, "localStorage", {
-    configurable: true,
-    value: {
-      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
-      setItem: (k: string, v: string) => void store.set(k, String(v)),
-      removeItem: (k: string) => void store.delete(k),
-      clear: () => store.clear(),
-      key: (i: number) => Array.from(store.keys())[i] ?? null,
-      get length() {
-        return store.size;
-      },
-    },
-  });
-}
-
 beforeEach(() => {
-  installMemoryStorage();
   fetchFromPan.mockReset();
 });
 

--- a/src/services/posting-time-recommendations.test.ts
+++ b/src/services/posting-time-recommendations.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   analyzePostingTimes,
   cacheAnalysis,
@@ -7,25 +7,6 @@ import {
   getDataDrivenPostingTimes,
   type PostTimingData,
 } from "./posting-time-recommendations";
-
-// Mock localStorage
-const localStorageMock = (() => {
-  let store: Record<string, string> = {};
-  return {
-    getItem: vi.fn((key: string) => store[key] || null),
-    setItem: vi.fn((key: string, value: string) => {
-      store[key] = value;
-    }),
-    removeItem: vi.fn((key: string) => {
-      delete store[key];
-    }),
-    clear: vi.fn(() => {
-      store = {};
-    }),
-  };
-})();
-
-Object.defineProperty(globalThis, "localStorage", { value: localStorageMock });
 
 function makePost(
   dayOfWeek: number,
@@ -118,7 +99,7 @@ describe("analyzePostingTimes", () => {
 
 describe("cache functions", () => {
   beforeEach(() => {
-    localStorageMock.clear();
+    localStorage.clear();
   });
 
   it("caches and retrieves analysis", () => {
@@ -142,7 +123,7 @@ describe("cache functions", () => {
       analysis,
       cachedAt: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString(), // 8 days ago
     };
-    localStorageMock.setItem(
+    localStorage.setItem(
       "posting-time-recommendations",
       JSON.stringify(oldCache),
     );
@@ -176,7 +157,7 @@ describe("fromApiResponse", () => {
 
 describe("getDataDrivenPostingTimes", () => {
   beforeEach(() => {
-    localStorageMock.clear();
+    localStorage.clear();
   });
 
   it("returns hardcoded defaults when no cache", () => {

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,6 +1,6 @@
 import "@testing-library/jest-dom";
 import "fake-indexeddb/auto";
-import { vi } from "vitest";
+import { afterEach, vi } from "vitest";
 
 // Mock window.matchMedia
 Object.defineProperty(window, "matchMedia", {
@@ -17,16 +17,33 @@ Object.defineProperty(window, "matchMedia", {
   })),
 });
 
-// Mock localStorage
-const localStorageMock = {
-  getItem: vi.fn(),
-  setItem: vi.fn(),
-  removeItem: vi.fn(),
-  clear: vi.fn(),
-  length: 0,
-  key: vi.fn(),
-};
-global.localStorage = localStorageMock as any;
+// In-memory localStorage that behaves like the real API:
+// - getItem returns null (not undefined) for missing keys
+// - setItem/removeItem/clear/key/length all work correctly
+// - Cleared between tests via afterEach in this file
+function createMemoryStorage(): Storage {
+  let store = new Map<string, string>();
+  return {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, String(v)),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => store.clear(),
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() {
+      return store.size;
+    },
+  };
+}
+
+Object.defineProperty(globalThis, "localStorage", {
+  configurable: true,
+  writable: true,
+  value: createMemoryStorage(),
+});
+
+afterEach(() => {
+  (globalThis as any).localStorage = createMemoryStorage();
+});
 
 // Mock document.cookie
 Object.defineProperty(document, "cookie", {


### PR DESCRIPTION
## Summary
The global test setup (`src/tests/setup.ts`) replaced `localStorage` with bare `vi.fn()` stubs that stored nothing and returned `undefined` for all `getItem` calls. This broke any test that needed localStorage round-trips and led to per-file workarounds (e.g., `installMemoryStorage()` in network-weather.test.ts). I replaced the no-op mock with a `Map`-backed in-memory `Storage` implementation that matches the real Web Storage API: `getItem` returns `null` for absent keys, `setItem` persists values, and `clear`/`removeItem`/`key`/`length` all work correctly. A fresh instance is installed via `afterEach` so state never leaks between tests. With the global mock now functional, I removed the `installMemoryStorage()` workaround from `network-weather.test.ts` and the file-local localStorage mock from `posting-time-recommendations.test.ts`. I audited all 8 test files that reference localStorage — the remaining file-local override in `useErrorTracking.test.ts` is necessary (it spies on `setItem` to test quota-exceeded error handling) and compatible with the new global mock. All 1345 tests across 69 files pass, build is clean, formatting is clean.

**Asana Task:** 1217171056973042
**Agent:** testing

_Auto-generated by task executor. Auto-merge enabled._