### PR TITLE
🟢 [Proactive] Clean up 2 skipped JS/TS tests in tests/visual-regression-

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bsky-notifications-app",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bsky-notifications-app",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "workspaces": [
         "packages/*"
       ],

--- a/tests/visual-regression-baseline.spec.ts
+++ b/tests/visual-regression-baseline.spec.ts
@@ -107,6 +107,8 @@ test.describe("Visual Regression Baseline - Landing Page", () => {
 });
 
 test.describe("Visual Regression Baseline - Authenticated", () => {
+  // Load-bearing: these tests login to a real Bluesky account to screenshot
+  // authenticated views — they cannot run without TEST_USER/TEST_PASS.
   test.skip(!hasCredentials(), "Requires test credentials");
 
   test.beforeEach(async ({ page }) => {
@@ -170,6 +172,7 @@ test.describe("Visual Regression Baseline - Error States", () => {
 
 // Component-specific detail tests
 test.describe("Component Details - Buttons", () => {
+  // Load-bearing: button-state screenshots require an authenticated session.
   test.skip(!hasCredentials(), "Requires test credentials");
 
   test.beforeEach(async ({ page }) => {


### PR DESCRIPTION
## Summary
Investigated the 2 `test.skip()` calls at lines 110 and 173 of `tests/visual-regression-baseline.spec.ts`. Both are conditional skips (`test.skip(!hasCredentials(), ...)`) that gate entire `describe` blocks containing Playwright visual regression tests requiring authentication against a real Bluesky account. Without `TEST_USER`/`TEST_PASS` environment variables, these tests cannot log in and thus cannot screenshot authenticated views (feed, profile, settings, button states). These are genuinely load-bearing skips — not suppressed failures. Added clear justification comments to each. **Removed: 0 | Kept with justification: 2.**

**Asana Task:** 1217243607896425
**Agent:** testing

_Auto-generated by task executor. Auto-merge enabled._