### PR TITLE
if a post has prior edits, make it easy and quick to see the oriiginal t

### DIFF
--- a/mobile/src/components/PostCardContent.tsx
+++ b/mobile/src/components/PostCardContent.tsx
@@ -13,7 +13,8 @@ import {
   AppBskyRichtextFacet,
 } from "@atproto/api";
 import { Avatar } from "./Avatar";
-import { ReplyIcon, MoreIcon, TranslateIcon, ShieldIcon } from "./icons";
+import { postEdit } from "@bsky/core";
+import { ReplyIcon, MoreIcon, TranslateIcon, ShieldIcon, PenIcon } from "./icons";
 import { RichText } from "../utils/rich-text";
 import { PostEmbed } from "./PostEmbed";
 import { InlineErrorBoundary } from "./ui/InlineErrorBoundary";
@@ -109,6 +110,9 @@ export function PostCardContent({
   onPressRepostCount,
 }: PostCardContentProps) {
   const styles = React.useMemo(() => createStyles(colors), [colors]);
+  const editedAt = postEdit.getEditedAt(record);
+  const originalText = postEdit.getOriginalText(record);
+  const [showOriginal, setShowOriginal] = React.useState(false);
 
   return (
     <View style={styles.content}>
@@ -187,6 +191,26 @@ export function PostCardContent({
         </TouchableOpacity>
         <View style={styles.headerRight}>
           <Text style={styles.timestamp}>{timestamp}</Text>
+          {editedAt && (
+            originalText ? (
+              <TouchableOpacity
+                style={styles.editedBadge}
+                onPress={() => setShowOriginal((v) => !v)}
+                activeOpacity={0.7}
+                accessibilityRole="button"
+                accessibilityLabel={`Edited — ${showOriginal ? "hide" : "show"} original text`}
+                accessibilityState={{ expanded: showOriginal }}
+              >
+                <PenIcon size={11} color={colors.textTertiary} />
+                <Text style={styles.editedText}>Edited</Text>
+              </TouchableOpacity>
+            ) : (
+              <View style={styles.editedBadge}>
+                <PenIcon size={11} color={colors.textTertiary} />
+                <Text style={styles.editedText}>Edited</Text>
+              </View>
+            )
+          )}
           {labels.length > 0 && !hideContent && (
             <ShieldIcon
               size={14}
@@ -224,6 +248,14 @@ export function PostCardContent({
             style={styles.text}
           />
         </InlineErrorBoundary>
+      )}
+
+      {/* Original text (pre-edit) */}
+      {showOriginal && originalText && (
+        <View style={styles.originalTextContainer}>
+          <Text style={styles.originalTextContent}>{originalText}</Text>
+          <Text style={styles.originalTextLabel}>Original text</Text>
+        </View>
       )}
 
       {/* Inline Translation */}
@@ -390,6 +422,32 @@ function createStyles(colors: any) {
       color: colors.textTertiary,
       fontSize: fontSize.footnote,
       marginRight: 4,
+    },
+    editedBadge: {
+      flexDirection: "row" as const,
+      alignItems: "center" as const,
+      gap: 3,
+    },
+    editedText: {
+      color: colors.textTertiary,
+      fontSize: fontSize.caption1,
+    },
+    originalTextContainer: {
+      borderLeftWidth: 2,
+      borderLeftColor: colors.textTertiary,
+      paddingLeft: 12,
+      marginBottom: 12,
+      marginTop: 4,
+    },
+    originalTextContent: {
+      color: colors.textSecondary,
+      fontSize: fontSize.footnote,
+      lineHeight: 18,
+    },
+    originalTextLabel: {
+      color: colors.textTertiary,
+      fontSize: fontSize.caption1,
+      marginTop: 4,
     },
     text: {
       color: colors.text,

--- a/packages/core/src/atproto/post-edit.test.ts
+++ b/packages/core/src/atproto/post-edit.test.ts
@@ -85,6 +85,22 @@ describe("@bsky/core post-edit", () => {
     }
   });
 
+  describe("getOriginalText", () => {
+    it("reads the non-lexicon originalText field", () => {
+      expect(postEdit.getOriginalText({ originalText: "helo wrold" })).toBe(
+        "helo wrold",
+      );
+    });
+
+    it("returns null when no originalText is present", () => {
+      expect(postEdit.getOriginalText(PRIOR_RECORD)).toBeNull();
+      expect(postEdit.getOriginalText({ originalText: "" })).toBeNull();
+      expect(postEdit.getOriginalText({ originalText: 42 })).toBeNull();
+      expect(postEdit.getOriginalText(undefined)).toBeNull();
+      expect(postEdit.getOriginalText(null)).toBeNull();
+    });
+  });
+
   describe("canEditPost", () => {
     const justAfter = new Date("2026-08-05T16:05:00.000Z");
     const wayAfter = new Date("2026-08-05T17:00:00.000Z");
@@ -250,6 +266,41 @@ describe("@bsky/core post-edit", () => {
         "2026-08-05T17:00:00.000Z",
       );
       expect(res.editedAt).toBe("2026-08-05T17:00:00.000Z");
+    });
+
+    it("stamps originalText with the pre-edit text on first edit", async () => {
+      const { agent, applyWrites } = stubAgent();
+      await postEdit.editPostText(agent, {
+        uri: POST_URI,
+        text: "hello world",
+      });
+
+      expect(createOpOf(applyWrites).value.originalText).toBe("helo wrold");
+    });
+
+    it("preserves originalText on re-edits", async () => {
+      const alreadyEdited = {
+        ...PRIOR_RECORD,
+        text: "hello world",
+        updatedAt: "2026-08-05T16:10:00.000Z",
+        originalText: "helo wrold",
+      };
+      const { agent, applyWrites } = stubAgent({
+        getRecord: vi
+          .fn()
+          .mockResolvedValueOnce({
+            data: { cid: "oldcid", value: alreadyEdited },
+          })
+          .mockResolvedValue({
+            data: { cid: "newcid", value: alreadyEdited },
+          }),
+      });
+      await postEdit.editPostText(agent, {
+        uri: POST_URI,
+        text: "hello world!",
+      });
+
+      expect(createOpOf(applyWrites).value.originalText).toBe("helo wrold");
     });
 
     it("drops stale byte-indexed fields so old offsets cannot corrupt new text", async () => {

--- a/packages/core/src/atproto/post-edit.ts
+++ b/packages/core/src/atproto/post-edit.ts
@@ -53,10 +53,17 @@ export const EDIT_WINDOW_MS = 15 * 60 * 1000;
  * Non-lexicon field carrying the edit timestamp. `app.bsky.feed.post` has no
  * edit field, but the PDS accepts unknown properties, and mu.social already
  * writes `updatedAt` — so using the same name buys cross-client interop for
- * free. We deliberately do NOT write mu.social's companion `originalText`: no
- * client renders it, and it publishes the pre-edit text permanently.
+ * free. mu.social also writes `originalText`; we now write it too so that
+ * users can quickly see what a post said before it was edited.
  */
 export const EDITED_AT_FIELD = "updatedAt";
+
+/**
+ * Non-lexicon field carrying the pre-edit text so viewers can see the original.
+ * Only stamped on the first edit; subsequent edits preserve the value so the
+ * very first version is always reachable.
+ */
+export const ORIGINAL_TEXT_FIELD = "originalText";
 
 /** Byte-indexed fields that a text change invalidates and must not survive it. */
 const TEXT_DEPENDENT_FIELDS = ["facets", "entities"] as const;
@@ -101,6 +108,17 @@ export function getEditedAt(record: unknown): string | null {
 
 export function isEdited(record: unknown): boolean {
   return getEditedAt(record) !== null;
+}
+
+/**
+ * Read the non-lexicon original-text field off a post record. Returns the
+ * pre-edit text when present, or null for posts that were never edited (or
+ * edited by a client that doesn't write this field).
+ */
+export function getOriginalText(record: unknown): string | null {
+  if (!record || typeof record !== "object") return null;
+  const value = (record as Record<string, unknown>)[ORIGINAL_TEXT_FIELD];
+  return typeof value === "string" && value.length > 0 ? value : null;
 }
 
 /**
@@ -232,6 +250,11 @@ export async function editPostText(
     text,
     [EDITED_AT_FIELD]: editedAt,
   };
+  // Stamp the pre-edit text on the first edit so viewers can see the original.
+  // On re-edits the field already exists and we leave it alone.
+  if (!prior[ORIGINAL_TEXT_FIELD] && typeof prior.text === "string") {
+    next[ORIGINAL_TEXT_FIELD] = prior.text;
+  }
   // Old byte offsets do not survive new text; drop them, then re-apply.
   for (const field of TEXT_DEPENDENT_FIELDS) delete next[field];
   if (facets && facets.length > 0) next.facets = facets;

--- a/src/components/PostRenderer.tsx
+++ b/src/components/PostRenderer.tsx
@@ -400,6 +400,8 @@ const PostRendererComponent: React.FC<PostRendererProps> = ({
   // Non-lexicon stamp, so no client shows an "edited" marker unless it looks for
   // it. Free to read — it rides along on the post view we already have.
   const editedAt = postEdit.getEditedAt(record);
+  const originalText = postEdit.getOriginalText(record);
+  const [showOriginal, setShowOriginal] = React.useState(false);
   const { getProfilePrefetchHandlers, getThreadPrefetchHandlers } =
     useRoutePrefetch();
 
@@ -1206,16 +1208,33 @@ const PostRendererComponent: React.FC<PostRendererProps> = ({
                     <span style={{ color: "var(--asph-text-secondary)" }}>
                       ·
                     </span>
-                    <span
-                      className="flex items-center gap-1 text-sm"
-                      style={{ color: "var(--asph-text-secondary)" }}
-                      title={`Edited ${formatDistanceToNow(new Date(editedAt), {
-                        addSuffix: true,
-                      })}`}
-                    >
-                      <Pencil size={12} aria-hidden="true" />
-                      <span className="text-xs">Edited</span>
-                    </span>
+                    {originalText ? (
+                      <button
+                        className="flex items-center gap-1 text-sm transition-colors hover:opacity-80"
+                        style={{ color: "var(--asph-text-secondary)" }}
+                        title={`Edited ${formatDistanceToNow(new Date(editedAt), { addSuffix: true })} — click to ${showOriginal ? "hide" : "show"} original`}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setShowOriginal((v) => !v);
+                        }}
+                        aria-expanded={showOriginal}
+                        aria-label={`Edited — ${showOriginal ? "hide" : "show"} original text`}
+                      >
+                        <Pencil size={12} aria-hidden="true" />
+                        <span className="text-xs underline decoration-dotted">
+                          Edited
+                        </span>
+                      </button>
+                    ) : (
+                      <span
+                        className="flex items-center gap-1 text-sm"
+                        style={{ color: "var(--asph-text-secondary)" }}
+                        title={`Edited ${formatDistanceToNow(new Date(editedAt), { addSuffix: true })}`}
+                      >
+                        <Pencil size={12} aria-hidden="true" />
+                        <span className="text-xs">Edited</span>
+                      </span>
+                    )}
                   </>
                 )}
                 {isThreadMutedState && (
@@ -1265,6 +1284,27 @@ const PostRendererComponent: React.FC<PostRendererProps> = ({
               <p className="asph-text-body whitespace-pre-wrap break-words">
                 <RichText text={record?.text || ""} facets={record?.facets} />
               </p>
+              {showOriginal && originalText && (
+                <div
+                  className="mt-2 rounded-lg border-l-2 pl-3"
+                  style={{
+                    borderColor: "var(--asph-text-tertiary)",
+                  }}
+                >
+                  <p
+                    className="whitespace-pre-wrap break-words text-sm"
+                    style={{ color: "var(--asph-text-secondary)" }}
+                  >
+                    {originalText}
+                  </p>
+                  <span
+                    className="mt-1 block text-xs"
+                    style={{ color: "var(--asph-text-tertiary)" }}
+                  >
+                    Original text
+                  </span>
+                </div>
+              )}
               {/* Inline Translation */}
               {isShowingTranslation && translatedText && (
                 <div


### PR DESCRIPTION
## Summary
Implemented "show original text" for edited posts across both web and mobile. The AT Protocol has no native edit, so Asphodel uses delete+create at the same rkey. Previously, the original text was lost after an edit. Now, `editPostText` stamps an `originalText` field (non-lexicon, like `updatedAt`) on the first edit, preserving the very first version across re-edits. This is compatible with mu.social's existing convention. On the web, the "Edited" badge becomes a clickable button (dotted underline affordance) that toggles an inline block showing the original text in a left-bordered style matching the existing translation UI. On mobile, a new "Edited" badge with pen icon appears in the post header, tappable to toggle the same original text display. The feature gracefully degrades: posts edited by older clients (without `originalText`) still show a non-interactive "Edited" badge.

**Asana Task:** 1217255494008400
**Agent:** frontend-specialist

_Auto-generated by task executor. Auto-merge enabled._