### PR TITLE
Make it possible to view and follow feeds from the feeds tabs on profile

### DIFF
--- a/src/config/routes.tsx
+++ b/src/config/routes.tsx
@@ -17,6 +17,7 @@ import { SearchTabbed as Search } from "../components/SearchTabbed";
 import { default as SkyDeck } from "../components/SkyDeck";
 import { VisualTimeline } from "../components/VisualTimeline";
 import { AddAccountPage } from "../pages/AddAccountPage";
+import { default as FeedPage } from "../pages/FeedPage";
 import { default as ProfilePage } from "../pages/ProfilePage";
 import { Settings } from "../pages/Settings";
 import { default as ThreadPage } from "../pages/ThreadPage";
@@ -32,6 +33,11 @@ function ProfilePageWithKey() {
 function ThreadPageWithKey() {
   const { handle, postId } = useParams<{ handle: string; postId: string }>();
   return <ThreadPage key={`${handle}/${postId}`} />;
+}
+
+function FeedPageWithKey() {
+  const { handle, rkey } = useParams<{ handle: string; rkey: string }>();
+  return <FeedPage key={`${handle}/${rkey}`} />;
 }
 
 function ListTimelineWithKey() {
@@ -156,6 +162,14 @@ export function AppRoutes() {
           element={
             <ErrorBoundary componentName="Scheduled Posts">
               <ScheduledPosts />
+            </ErrorBoundary>
+          }
+        />
+        <Route
+          path="/profile/:handle/feed/:rkey"
+          element={
+            <ErrorBoundary componentName="Feed">
+              <FeedPageWithKey />
             </ErrorBoundary>
           }
         />

--- a/src/pages/FeedPage.tsx
+++ b/src/pages/FeedPage.tsx
@@ -1,0 +1,255 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  ArrowLeft,
+  Check,
+  ExternalLink,
+  Hash,
+  Heart,
+  Plus,
+  Users,
+} from "lucide-react";
+import { useCallback } from "react";
+import { useParams } from "react-router";
+import { ErrorBoundary } from "../components/ErrorBoundary";
+import { Home } from "../components/Home";
+import { FeedSkeleton } from "../components/ui/SkeletonLoader";
+import { useAuth } from "../contexts/AuthContext";
+import { useViewTransitionNavigate } from "../hooks/useViewTransitionNavigate";
+import { proxifyBskyImage } from "../utils/image-proxy";
+
+export default function FeedPage() {
+  const { handle, rkey } = useParams<{ handle: string; rkey: string }>();
+  const navigate = useViewTransitionNavigate();
+  const { agent } = useAuth();
+  const queryClient = useQueryClient();
+
+  const feedUri = `at://${handle}/app.bsky.feed.generator/${rkey}`;
+
+  const { data: feedInfo, isLoading: isLoadingInfo } = useQuery({
+    queryKey: ["feedGenerator", feedUri],
+    queryFn: async () => {
+      if (!agent) throw new Error("Not authenticated");
+      const response = await agent.app.bsky.feed.getFeedGenerator({
+        feed: feedUri,
+      });
+      return response.data;
+    },
+    enabled: !!agent && !!handle && !!rkey,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const feed = feedInfo?.view;
+  // Use the canonical DID-based URI from the API response for saved feed
+  // operations, since saved feeds store DID-based URIs while the URL uses handles.
+  const canonicalUri = feed?.uri ?? feedUri;
+
+  const { data: userPrefs } = useQuery({
+    queryKey: ["userPreferences"],
+    queryFn: async () => {
+      if (!agent) throw new Error("Not authenticated");
+      return await agent.getPreferences();
+    },
+    enabled: !!agent,
+  });
+
+  const isSaved =
+    userPrefs?.savedFeeds?.some((f: any) => f.value === canonicalUri) ?? false;
+
+  const addFeedMutation = useMutation({
+    mutationFn: async () => {
+      if (!agent) throw new Error("Not authenticated");
+      const newSavedFeed = {
+        id: `feed-${Date.now()}`,
+        type: "feed" as const,
+        value: canonicalUri,
+        pinned: false,
+      };
+      await agent.addSavedFeeds([newSavedFeed]);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["userPreferences"] });
+    },
+  });
+
+  const removeFeedMutation = useMutation({
+    mutationFn: async () => {
+      if (!agent || !userPrefs?.savedFeeds)
+        throw new Error("Not authenticated");
+      const feedToRemove = userPrefs.savedFeeds.find(
+        (f: any) => f.value === canonicalUri,
+      );
+      if (feedToRemove) {
+        await agent.removeSavedFeeds([feedToRemove.id]);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["userPreferences"] });
+    },
+  });
+
+  const handleToggleSave = useCallback(() => {
+    if (isSaved) {
+      removeFeedMutation.mutate();
+    } else {
+      addFeedMutation.mutate();
+    }
+  }, [isSaved, addFeedMutation, removeFeedMutation]);
+
+  const isMutating = addFeedMutation.isPending || removeFeedMutation.isPending;
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header */}
+      <div
+        className="sticky top-0 z-10 border-b"
+        style={{
+          borderColor: "var(--asph-border-primary)",
+          backgroundColor: "var(--asph-bg-primary)",
+        }}
+      >
+        <div className="flex items-center gap-3 px-4 py-3">
+          <button
+            onClick={() => navigate(-1)}
+            className="touch-target-icon rounded-full p-1.5 transition-colors hover:bg-asph-bg-active"
+          >
+            <ArrowLeft
+              className="h-5 w-5"
+              style={{ color: "var(--asph-text-primary)" }}
+            />
+          </button>
+
+          {isLoadingInfo ? (
+            <div className="flex-1">
+              <div
+                className="h-5 w-32 animate-pulse rounded"
+                style={{ backgroundColor: "var(--asph-bg-tertiary)" }}
+              />
+            </div>
+          ) : feed ? (
+            <div className="flex min-w-0 flex-1 items-center gap-3">
+              {feed.avatar ? (
+                <img
+                  src={proxifyBskyImage(feed.avatar)}
+                  alt={feed.displayName}
+                  className="h-8 w-8 flex-shrink-0 rounded-lg object-cover"
+                />
+              ) : (
+                <div
+                  className="flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-lg"
+                  style={{ backgroundColor: "var(--asph-bg-tertiary)" }}
+                >
+                  <Hash
+                    className="h-4 w-4"
+                    style={{ color: "var(--asph-text-secondary)" }}
+                  />
+                </div>
+              )}
+              <div className="min-w-0 flex-1">
+                <h1
+                  className="truncate text-sm font-semibold"
+                  style={{ color: "var(--asph-text-primary)" }}
+                >
+                  {feed.displayName}
+                </h1>
+                <p
+                  className="truncate text-xs"
+                  style={{ color: "var(--asph-text-secondary)" }}
+                >
+                  by @{feed.creator.handle}
+                </p>
+              </div>
+            </div>
+          ) : null}
+
+          <div className="flex items-center gap-2">
+            <button
+              onClick={handleToggleSave}
+              disabled={isMutating}
+              className="flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium transition-colors"
+              style={{
+                backgroundColor: isSaved
+                  ? "transparent"
+                  : "var(--asph-primary)",
+                border: isSaved
+                  ? "1px solid var(--asph-border-primary)"
+                  : "1px solid transparent",
+                color: isSaved ? "var(--asph-text-secondary)" : "white",
+                opacity: isMutating ? 0.6 : 1,
+              }}
+            >
+              {isSaved ? (
+                <>
+                  <Check className="h-3.5 w-3.5" />
+                  Saved
+                </>
+              ) : (
+                <>
+                  <Plus className="h-3.5 w-3.5" />
+                  Save
+                </>
+              )}
+            </button>
+            <a
+              href={`https://bsky.app/profile/${handle}/feed/${rkey}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="touch-target-icon rounded-full p-1.5 transition-colors hover:bg-asph-bg-active"
+            >
+              <ExternalLink
+                className="h-4 w-4"
+                style={{ color: "var(--asph-text-secondary)" }}
+              />
+            </a>
+          </div>
+        </div>
+
+        {/* Feed description */}
+        {feed?.description && (
+          <div
+            className="border-t px-4 py-2"
+            style={{ borderColor: "var(--asph-border-primary)" }}
+          >
+            <p
+              className="text-xs leading-relaxed"
+              style={{ color: "var(--asph-text-secondary)" }}
+            >
+              {feed.description}
+            </p>
+            <div className="mt-1 flex items-center gap-3 text-xs">
+              {feed.likeCount !== undefined && (
+                <span
+                  className="flex items-center gap-1"
+                  style={{ color: "var(--asph-text-tertiary)" }}
+                >
+                  <Heart className="h-3 w-3" />
+                  {feed.likeCount.toLocaleString()} likes
+                </span>
+              )}
+              <button
+                onClick={() => navigate(`/profile/${feed.creator.handle}`)}
+                className="flex items-center gap-1 hover:underline"
+                style={{ color: "var(--asph-primary)" }}
+              >
+                <Users className="h-3 w-3" />
+                {feed.creator.displayName || `@${feed.creator.handle}`}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Feed content */}
+      <div className="flex-1">
+        {isLoadingInfo ? (
+          <div className="p-4">
+            <FeedSkeleton count={5} />
+          </div>
+        ) : (
+          <ErrorBoundary componentName="Feed">
+            <Home feedUri={feedUri} isFocused isVisible />
+          </ErrorBoundary>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -2,6 +2,7 @@ import { AppBskyFeedDefs, RichText as BskyRichText } from "@atproto/api";
 import { getProfileService } from "@bsky/shared";
 import {
   useInfiniteQuery,
+  useMutation,
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
@@ -9,6 +10,7 @@ import {
   BadgeCheck,
   BarChart3,
   Calendar,
+  Check,
   ChevronDown,
   ChevronUp,
   Edit,
@@ -19,6 +21,7 @@ import {
   List as ListIcon,
   MoreHorizontal,
   Pin,
+  Plus,
   QrCode,
   Rss,
   Share2,
@@ -316,6 +319,54 @@ export default function ProfilePage() {
     },
     staleTime: 5 * 60 * 1000,
     enabled: !!agent && !!handle && hasFeedgens,
+  });
+
+  // User preferences for checking saved feeds
+  const { data: userPrefs } = useQuery({
+    queryKey: ["userPreferences"],
+    queryFn: async () => {
+      if (!agent) throw new Error("Not authenticated");
+      return await agent.getPreferences();
+    },
+    enabled: !!agent && hasFeedgens,
+  });
+
+  const isFeedSaved = useCallback(
+    (feedUri: string) =>
+      userPrefs?.savedFeeds?.some((f: any) => f.value === feedUri) ?? false,
+    [userPrefs?.savedFeeds],
+  );
+
+  const addFeedMutation = useMutation({
+    mutationFn: async (feedUri: string) => {
+      if (!agent) throw new Error("Not authenticated");
+      const newSavedFeed = {
+        id: `feed-${Date.now()}`,
+        type: "feed" as const,
+        value: feedUri,
+        pinned: false,
+      };
+      await agent.addSavedFeeds([newSavedFeed]);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["userPreferences"] });
+    },
+  });
+
+  const removeFeedMutation = useMutation({
+    mutationFn: async (feedUri: string) => {
+      if (!agent || !userPrefs?.savedFeeds)
+        throw new Error("Not authenticated");
+      const feedToRemove = userPrefs.savedFeeds.find(
+        (f: any) => f.value === feedUri,
+      );
+      if (feedToRemove) {
+        await agent.removeSavedFeeds([feedToRemove.id]);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["userPreferences"] });
+    },
   });
 
   const [aiInsightsExpanded, setAiInsightsExpanded] = useState(false);
@@ -1634,80 +1685,123 @@ export default function ProfilePage() {
               </div>
             ) : actorFeedsData?.feeds && actorFeedsData.feeds.length > 0 ? (
               <div className="space-y-3">
-                {actorFeedsData.feeds.map((feed) => (
-                  <div
-                    key={feed.uri}
-                    className="flex cursor-pointer items-start gap-3 rounded-xl border p-4 transition-all duration-200 hover:shadow-md"
-                    style={{
-                      borderColor: "var(--asph-border-primary)",
-                      backgroundColor: "var(--asph-bg-secondary)",
-                    }}
-                    onClick={() => {
-                      const rkey = feed.uri.split("/").pop();
-                      window.open(
-                        `https://bsky.app/profile/${feed.creator.handle}/feed/${rkey}`,
-                        "_blank",
-                        "noopener,noreferrer",
-                      );
-                    }}
-                  >
-                    {feed.avatar ? (
-                      <img
-                        src={proxifyBskyImage(feed.avatar)}
-                        alt={feed.displayName}
-                        className="h-12 w-12 flex-shrink-0 rounded-lg object-cover"
-                      />
-                    ) : (
-                      <div
-                        className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-lg"
-                        style={{ backgroundColor: "var(--asph-bg-tertiary)" }}
-                      >
-                        <Hash
-                          className="h-5 w-5"
-                          style={{ color: "var(--asph-text-secondary)" }}
+                {actorFeedsData.feeds.map((feed) => {
+                  const feedRkey = feed.uri.split("/").pop();
+                  const saved = isFeedSaved(feed.uri);
+                  return (
+                    <div
+                      key={feed.uri}
+                      className="flex cursor-pointer items-start gap-3 rounded-xl border p-4 transition-all duration-200 hover:shadow-md"
+                      style={{
+                        borderColor: "var(--asph-border-primary)",
+                        backgroundColor: "var(--asph-bg-secondary)",
+                      }}
+                      onClick={() => {
+                        navigate(
+                          `/profile/${feed.creator.handle}/feed/${feedRkey}`,
+                        );
+                      }}
+                    >
+                      {feed.avatar ? (
+                        <img
+                          src={proxifyBskyImage(feed.avatar)}
+                          alt={feed.displayName}
+                          className="h-12 w-12 flex-shrink-0 rounded-lg object-cover"
                         />
-                      </div>
-                    )}
-                    <div className="min-w-0 flex-1">
-                      <h3
-                        className="font-semibold"
-                        style={{ color: "var(--asph-text-primary)" }}
-                      >
-                        {feed.displayName}
-                      </h3>
-                      {feed.description && (
-                        <p
-                          className="mt-1 line-clamp-2 text-sm"
-                          style={{ color: "var(--asph-text-secondary)" }}
+                      ) : (
+                        <div
+                          className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-lg"
+                          style={{
+                            backgroundColor: "var(--asph-bg-tertiary)",
+                          }}
                         >
-                          {feed.description}
-                        </p>
+                          <Hash
+                            className="h-5 w-5"
+                            style={{ color: "var(--asph-text-secondary)" }}
+                          />
+                        </div>
                       )}
-                      <div className="mt-2 flex items-center gap-3 text-xs">
-                        {feed.likeCount !== undefined && (
-                          <span
-                            className="flex items-center gap-1"
-                            style={{ color: "var(--asph-text-tertiary)" }}
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-start justify-between gap-2">
+                          <h3
+                            className="font-semibold"
+                            style={{ color: "var(--asph-text-primary)" }}
                           >
-                            <Heart className="h-3 w-3" />
-                            {feed.likeCount.toLocaleString()}
-                          </span>
+                            {feed.displayName}
+                          </h3>
+                          <button
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              if (saved) {
+                                removeFeedMutation.mutate(feed.uri);
+                              } else {
+                                addFeedMutation.mutate(feed.uri);
+                              }
+                            }}
+                            disabled={
+                              addFeedMutation.isPending ||
+                              removeFeedMutation.isPending
+                            }
+                            className="flex flex-shrink-0 items-center gap-1 rounded-full px-3 py-1.5 text-xs font-medium transition-colors"
+                            style={{
+                              backgroundColor: saved
+                                ? "transparent"
+                                : "var(--asph-primary)",
+                              border: saved
+                                ? "1px solid var(--asph-border-primary)"
+                                : "1px solid transparent",
+                              color: saved
+                                ? "var(--asph-text-secondary)"
+                                : "white",
+                            }}
+                          >
+                            {saved ? (
+                              <>
+                                <Check className="h-3 w-3" />
+                                Saved
+                              </>
+                            ) : (
+                              <>
+                                <Plus className="h-3 w-3" />
+                                Save
+                              </>
+                            )}
+                          </button>
+                        </div>
+                        {feed.description && (
+                          <p
+                            className="mt-1 line-clamp-2 text-sm"
+                            style={{ color: "var(--asph-text-secondary)" }}
+                          >
+                            {feed.description}
+                          </p>
                         )}
-                        <a
-                          href={`https://bsky.app/profile/${feed.creator.handle}/feed/${feed.uri.split("/").pop()}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          onClick={(e) => e.stopPropagation()}
-                          className="flex items-center gap-1 hover:underline"
-                          style={{ color: "var(--asph-primary)" }}
-                        >
-                          <ExternalLink className="h-3 w-3" />
-                          View
-                        </a>
+                        <div className="mt-2 flex items-center gap-3 text-xs">
+                          {feed.likeCount !== undefined && (
+                            <span
+                              className="flex items-center gap-1"
+                              style={{ color: "var(--asph-text-tertiary)" }}
+                            >
+                              <Heart className="h-3 w-3" />
+                              {feed.likeCount.toLocaleString()}
+                            </span>
+                          )}
+                          <a
+                            href={`https://bsky.app/profile/${feed.creator.handle}/feed/${feedRkey}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            onClick={(e) => e.stopPropagation()}
+                            className="flex items-center gap-1 hover:underline"
+                            style={{ color: "var(--asph-primary)" }}
+                          >
+                            <ExternalLink className="h-3 w-3" />
+                            View on Bluesky
+                          </a>
+                        </div>
                       </div>
                     </div>
-                  </div>
-                ))}
+                  );
+                })}
               </div>
             ) : (
               <EmptyState


### PR DESCRIPTION
## Summary
Implemented in-app feed viewing and follow/save functionality for the profile feeds tab. Previously, the feeds tab on profiles only showed feed cards that opened externally on bsky.app. Now: (1) Clicking a feed card navigates to a new in-app FeedPage at `/profile/:handle/feed/:rkey` that shows the feed's metadata (avatar, name, description, creator, like count) in a sticky header and renders the feed's posts using the existing `Home` component. (2) Each feed card on the profile page and the FeedPage header includes a Save/Saved toggle button using the established `agent.addSavedFeeds()`/`agent.removeSavedFeeds()` pattern (matching FeedDiscovery and DiscoverFeeds components). The FeedPage uses the canonical DID-based URI from the API response for saved feed operations to ensure proper matching against the user's saved feeds list.

**Asana Task:** 1217283869833039
**Agent:** frontend-specialist

_Auto-generated by task executor. Auto-merge enabled._